### PR TITLE
Fix initialization for Leaflet@1.8

### DIFF
--- a/leaflet.rrose-src.js
+++ b/leaflet.rrose-src.js
@@ -118,10 +118,20 @@ L.Rrose = L.Popup.extend({
     this._container.style.left = this._containerLeft + 'px';
   }
 
+
   _LversionLowerThan:function(version) {
-    function versionToNumeric(version) {
-      return +version.match(/\d+/g).join('');
-    }
-    return versionToNumeric(L.version) < versionToNumeric(version);
+		function versionLowerThan(v1, v2) {
+			var [a1, a2] = [v1, v2].map(v => v.match(/\d+/g));
+			for (var i = 0; i < Math.max(a1.length, a2.length); i++) {
+				var [part1, part2] = [a1, a2].map(a => a[i] || 0);
+				if (part1 < part2) {
+					return true;
+				} else if (part1 > part2) {
+					return false;
+				}
+			}
+			return false;
+		}
+		return versionLowerThan(L.version, version);
   }
 });

--- a/leaflet.rrose-src.js
+++ b/leaflet.rrose-src.js
@@ -27,9 +27,13 @@ L.Rrose = L.Popup.extend({
       closeButton.href = '#close';
       closeButton.innerHTML = '&#215;';
 
-    this._LversionLowerThan('1.8.0')
-      ? L.DomEvent.on(closeButton, 'click', this._onCloseButtonClick, this)
-      : L.DomEvent.on(closeButton, 'click', this.close, this);
+
+			if (this._LversionLowerThan('1.8.0')) {
+				L.DomEvent.on(closeButton, 'click', this._onCloseButtonClick, this)
+			} else {
+				L.DomEvent.on(closeButton, 'click', L.DomEvent.preventDefault, this);
+				L.DomEvent.on(closeButton, 'click', this.close, this);
+			}
     }
 
     // Set the pixel distances from the map edges at which popups are too close and need to be re-oriented.
@@ -120,6 +124,4 @@ L.Rrose = L.Popup.extend({
     }
     return versionToNumeric(L.version) < versionToNumeric(version);
   }
-
-
 });

--- a/leaflet.rrose-src.js
+++ b/leaflet.rrose-src.js
@@ -27,7 +27,7 @@ L.Rrose = L.Popup.extend({
       closeButton.href = '#close';
       closeButton.innerHTML = '&#215;';
 
-      L.DomEvent.on(closeButton, 'click', this._onCloseButtonClick, this);
+      L.DomEvent.on(closeButton, 'click', this.close, this);
     }
 
     // Set the pixel distances from the map edges at which popups are too close and need to be re-oriented.

--- a/leaflet.rrose-src.js
+++ b/leaflet.rrose-src.js
@@ -27,7 +27,9 @@ L.Rrose = L.Popup.extend({
       closeButton.href = '#close';
       closeButton.innerHTML = '&#215;';
 
-      L.DomEvent.on(closeButton, 'click', this.close, this);
+    this._LversionLowerThan('1.8.0')
+      ? L.DomEvent.on(closeButton, 'click', this._onCloseButtonClick, this)
+      : L.DomEvent.on(closeButton, 'click', this.close, this);
     }
 
     // Set the pixel distances from the map edges at which popups are too close and need to be re-oriented.
@@ -111,5 +113,13 @@ L.Rrose = L.Popup.extend({
     this._container.style.bottom = this._containerBottom + 'px';
     this._container.style.left = this._containerLeft + 'px';
   }
+
+  _LversionLowerThan:function(version) {
+    function versionToNumeric(version) {
+      return +version.match(/\d+/g).join('');
+    }
+    return versionToNumeric(L.version) < versionToNumeric(version);
+  }
+
 
 });


### PR DESCRIPTION
This PR replaces the `_onCloseButtonClick()` call on initialization with `close()` according to `leaflet@1.8` breaking changes. Leaflet's `Popup` API internals were reorganized according to their [changelog](https://github.com/Leaflet/Leaflet/releases/tag/v1.8.0):

> * Reorganize DivOverlay/Popup/Tooltip APIs